### PR TITLE
feat: patch decompress_pubkey & add from_hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ edition = "2021"
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
+[dependencies]
+sp1_precompiles = { git = "https://github.com/succinctlabs/sp1.git", package = "sp1-precompiles" }
+
 [dev-dependencies]
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
 criterion = "0.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
-components = [ "clippy", "rustfmt" ]
+channel = "nightly-2024-04-17"
+components = ["llvm-tools", "rustc-dev"]

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -14,7 +14,6 @@ use sp1_precompiles::bls12381::decompress_pubkey;
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
 
-
 use crate::fp::Fp;
 use crate::Scalar;
 
@@ -278,7 +277,6 @@ impl G1Affine {
     /// API invariants may be broken.** Please consider using `from_uncompressed()` instead.
     pub fn from_uncompressed_unchecked(bytes: &[u8; 96]) -> CtOption<Self> {
         // Obtain the three flags from the start of the byte sequence
-
         let compression_flag_set = Choice::from((bytes[0] >> 7) & 1);
         let infinity_flag_set = Choice::from((bytes[0] >> 6) & 1);
         let sort_flag_set = Choice::from((bytes[0] >> 5) & 1);
@@ -326,7 +324,6 @@ impl G1Affine {
                 )
             })
         })
-
     }
 
     /// Attempts to deserialize a compressed element. See [`notes::serialization`](crate::notes::serialization)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! * This implementation does not require the Rust standard library.
 //! * All operations are constant time unless explicitly noted.
 
-#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 //! * This implementation targets Rust `1.36` or later.
 //! * This implementation does not require the Rust standard library.
 //! * All operations are constant time unless explicitly noted.
-
+//! 
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * This implementation targets Rust `1.36` or later.
 //! * This implementation does not require the Rust standard library.
 //! * All operations are constant time unless explicitly noted.
-//! 
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Catch documentation errors caused by code changes.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -335,6 +335,28 @@ impl Scalar {
     pub const fn from_raw(val: [u64; 4]) -> Self {
         (&Scalar(val)).mul(&R2)
     }
+    
+    /// Converts from a hex string into its `Scalar` representation.
+    pub fn from_hex(hex: &str) -> Option<Self> {
+        if hex.len() != 64 {
+            return None;
+        }
+
+        let mut raw = [0u64; 4];
+        for (i, chunk) in hex.as_bytes().chunks(16).enumerate().take(4) {
+            if let Ok(hex_chunk) = core::str::from_utf8(chunk) {
+                if let Ok(value) = u64::from_str_radix(hex_chunk, 16) {
+                    raw[3 - i] = value.to_le();
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
+
+        Some(Scalar::from_raw(raw))
+    }
 
     /// Squares this element.
     #[inline]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -232,6 +232,30 @@ impl Default for Scalar {
 impl zeroize::DefaultIsZeroes for Scalar {}
 
 impl Scalar {
+    pub const CURVE_ORDER: [u64; 7] = [
+        0x3FFFFFF00000001,
+        0x36900BFFF96FFBF,
+        0x180809A1D80553B,
+        0x14CA675F520CCE7,
+        0x73EDA7,
+        0x0,
+        0x0,
+    ];
+
+    pub fn from_curve_order() -> Self {
+        let mut tmp = Self([0, 0, 0, 0]);
+        let mut carry = 0u64;
+
+        for (i, chunk) in Self::CURVE_ORDER.iter().enumerate() {
+            let (lo, hi) = mul_u64(*chunk, R2.0[0]);
+            let (res, new_carry) = adc(tmp.0[i], lo, carry);
+            tmp.0[i] = res;
+            carry = hi.wrapping_add(new_carry);
+        }
+
+        tmp
+    }
+
     /// Returns zero, the additive identity.
     #[inline]
     pub const fn zero() -> Scalar {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -232,7 +232,6 @@ impl Default for Scalar {
 impl zeroize::DefaultIsZeroes for Scalar {}
 
 impl Scalar {
-
     /// Returns zero, the additive identity.
     #[inline]
     pub const fn zero() -> Scalar {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -232,29 +232,6 @@ impl Default for Scalar {
 impl zeroize::DefaultIsZeroes for Scalar {}
 
 impl Scalar {
-    pub const CURVE_ORDER: [u64; 7] = [
-        0x3FFFFFF00000001,
-        0x36900BFFF96FFBF,
-        0x180809A1D80553B,
-        0x14CA675F520CCE7,
-        0x73EDA7,
-        0x0,
-        0x0,
-    ];
-
-    pub fn from_curve_order() -> Self {
-        let mut tmp = Self([0, 0, 0, 0]);
-        let mut carry = 0u64;
-
-        for (i, chunk) in Self::CURVE_ORDER.iter().enumerate() {
-            let (lo, hi) = mul_u64(*chunk, R2.0[0]);
-            let (res, new_carry) = adc(tmp.0[i], lo, carry);
-            tmp.0[i] = res;
-            carry = hi.wrapping_add(new_carry);
-        }
-
-        tmp
-    }
 
     /// Returns zero, the additive identity.
     #[inline]


### PR DESCRIPTION
1. patch decompress_pubkey in g1.rs, massive zkvm speed improvement
2. add from_hex in scalar.rs to load a scalar from a hex representation